### PR TITLE
Fix for signup/login

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+eslint:
+  enabled: true
+  config_file: .eslintrc

--- a/components/CreateFamilyPage.js
+++ b/components/CreateFamilyPage.js
@@ -16,6 +16,9 @@ import {
 import { createFamilyStyles as styles } from '../styles';
 
 export default class CreateFamilyPage extends Component {
+  static navigationOptions = {
+    title: 'Create family',
+  };
   constructor(props) {
     super(props);
     this.state = {

--- a/components/LoginPage.js
+++ b/components/LoginPage.js
@@ -1,4 +1,4 @@
-
+/* eslint-disable no-console */
 import React, { Component } from 'react';
 import {
   Text,

--- a/components/LoginPage.js
+++ b/components/LoginPage.js
@@ -35,14 +35,14 @@ class LoginPage extends Component {
         this.props.authenticateUserMutation({ variables: { email, password } });
       const { navigate } = this.props.navigation;
       const tokenToString = response.data.authenticateUser.token.toString();
-      this._storeAuthTokensLocally(tokenToString);
+      this.storeAuthTokensLocally(tokenToString);
       navigate('CreateFamilyPage');
     } catch (e) {
       console.error('An error occurred: ', e);
     }
   }
 
-  _storeAuthTokensLocally = async (graphcoolToken) => {
+  storeAuthTokensLocally = async (graphcoolToken) => {
     await AsyncStorage.setItem('graphcoolToken', graphcoolToken);
   }
 

--- a/components/SignupPage.js
+++ b/components/SignupPage.js
@@ -45,14 +45,14 @@ class SignupPage extends Component {
       });
       const { navigate } = this.props.navigation;
       const tokenToString = response.data.signupUser.token.toString();
-      this._storeAuthTokensLocally(tokenToString);
+      this.storeAuthTokensLocally(tokenToString);
       // Did not destructure because the variable name firstName exists
       navigate('CreateFamilyPage', { name: response.data.signupUser.firstName });
     } catch (e) {
       console.error('An error occurred: ', e);
     }
   }
-  _handleFacebookLogin = async () => {
+  handleFacebookLogin = async () => {
     try {
       const { type, token, expires } = await Facebook.logInWithReadPermissionsAsync(
         '641679006221114',
@@ -70,7 +70,7 @@ class SignupPage extends Component {
               const { navigate } = this.props.navigation;
               const tokenToString = data.authenticateFacebookUser.token.toString();
               navigate('CreateFamilyPage');
-              this._storeAuthTokensLocally(
+              this.storeAuthTokensLocally(
                 tokenToString,
                 token.toString(),
                 expires.toString()
@@ -105,7 +105,7 @@ class SignupPage extends Component {
     }
   };
 
-  _storeAuthTokensLocally = async (graphcoolToken, socialLoginToken, socialLoginValidity) => {
+  storeAuthTokensLocally = async (graphcoolToken, socialLoginToken, socialLoginValidity) => {
     await AsyncStorage.setItem('graphcoolToken', graphcoolToken);
     await AsyncStorage.setItem('socialLoginToken', socialLoginToken);
     await AsyncStorage.setItem('socialLoginValidity', socialLoginValidity);
@@ -118,7 +118,7 @@ class SignupPage extends Component {
         <Text>Sign up with </Text>
         <View style={styles.socialMediaSectionStyles}>
            <TouchableHighlight
-           onPress={this._handleFacebookLogin}>
+           onPress={this.handleFacebookLogin}>
            <Text style={styles.linkStyle}> Facebook </Text>
            </TouchableHighlight>
            <Text>or</Text>

--- a/components/SignupPage.js
+++ b/components/SignupPage.js
@@ -28,17 +28,30 @@ class SignupPage extends Component {
     input: PropTypes.object,
     handleSubmit: PropTypes.func,
     authenticateUserMutation: PropTypes.func,
+    signupUserMutation: PropTypes.func,
     navigation: PropTypes.object
   }
 
-  handlePress = (values) => {
-    this.props.signup(values).then((response) => {
+  handlePress = async (values) => {
+    const {
+      firstName, lastName, email, password, passwordConfirm, phoneNum
+    } = values;
+    console.log(email, password);
+    try {
+      const response = await this.props.signupUserMutation({
+        variables: {
+          firstName, lastName, email, password, passwordConfirm, phoneNum
+        }
+      });
       const { navigate } = this.props.navigation;
-      navigate('CreateFamilyPage');
-      console.log(response.data);
-    }).catch(err => console.log(err));
+      const tokenToString = response.data.signupUser.token.toString();
+      this._storeAuthTokensLocally(tokenToString);
+      // Did not destructure because the variable name firstName exists
+      navigate('CreateFamilyPage', { name: response.data.signupUser.firstName });
+    } catch (e) {
+      console.error('An error occurred: ', e);
+    }
   }
-
   _handleFacebookLogin = async () => {
     try {
       const { type, token, expires } = await Facebook.logInWithReadPermissionsAsync(
@@ -164,7 +177,7 @@ class SignupPage extends Component {
 }
 
 const SIGNUP_MUTATION = gql`
-  mutation createUser(
+  mutation SignupUser(
     $firstName: String!,
     $lastName : String!,
     $email: String!,
@@ -172,15 +185,15 @@ const SIGNUP_MUTATION = gql`
     $passwordConfirm: String!,
     $phoneNum: String!
   ){
-    createUser(
+    signupUser(
       firstName: $firstName,
       lastName: $lastName,
       email: $email,
       password: $password,
       passwordConfirm: $passwordConfirm,
       phoneNum: $phoneNum) {
+        token
         firstName
-        email
     }
   }
 `;
@@ -199,34 +212,13 @@ query LoggedInUser {
   }
 }`;
 
-const SignupWithData = graphql(SIGNUP_MUTATION, {
-  props: ({ mutate }) => ({
-    signup: ({
-      firstName,
-      lastName,
-      email,
-      password,
-      passwordConfirm,
-      phoneNum
-    }) => mutate({
-      variables: {
-        firstName,
-        lastName,
-        email,
-        password,
-        passwordConfirm,
-        phoneNum
-      }
-    }),
-  }),
-})(SignupPage);
-
 const SignupForm = reduxForm({
   form: 'signup',
   validate,
-})(SignupWithData);
+})(SignupPage);
 
 const SignupWithMutation = compose(
+  graphql(SIGNUP_MUTATION, { name: 'signupUserMutation' }),
   graphql(AUTH_FB_USER, { name: 'authenticateUserMutation' }),
   graphql(LOGGED_IN_USER, { options: { fetchPolicy: 'network-only' } })
 )(SignupForm);

--- a/server/src/email-password/signup.graphql
+++ b/server/src/email-password/signup.graphql
@@ -5,5 +5,11 @@ type SignupUserPayload {
 }
 
 extend type Mutation {
-  signupUser(firstName: String!, lastName : String!, email: String!, password: String!, passwordConfirm: String!, phoneNum: String!): SignupUserPayload
+  signupUser(
+    firstName: String!,
+    lastName : String!,
+    email: String!,
+    password: String!,
+    passwordConfirm: String!,
+    phoneNum: String!): SignupUserPayload
 }

--- a/server/src/email-password/signup.graphql
+++ b/server/src/email-password/signup.graphql
@@ -1,8 +1,9 @@
 type SignupUserPayload {
   id: ID!
   token: String!
+  firstName: String!
 }
 
 extend type Mutation {
-  signupUser(email: String!, password: String!): SignupUserPayload
+  signupUser(firstName: String!, lastName : String!, email: String!, password: String!, passwordConfirm: String!, phoneNum: String!): SignupUserPayload
 }

--- a/server/src/email-password/signup.ts
+++ b/server/src/email-password/signup.ts
@@ -25,7 +25,14 @@ export default async (event: FunctionEvent<EventData>) => {
     const graphcool = fromEvent(event)
     const api = graphcool.api('simple/v1')
 
-    const { firstName, lastName, email, password, passwordConfirm, phoneNum } = event.data
+    const {
+      firstName,
+      lastName,
+      email,
+      password,
+      passwordConfirm,
+      phoneNum
+    } = event.data
 
     if (!validator.isEmail(email)) {
       return { error: 'Not a valid email' }
@@ -43,7 +50,15 @@ export default async (event: FunctionEvent<EventData>) => {
     const hash = await bcrypt.hash(password, SALT_ROUNDS)
 
     // create new user
-    const userId = await createGraphcoolUser(api, firstName, lastName, email, hash, passwordConfirm, phoneNum)
+    const userId = await createGraphcoolUser(
+      api,
+      firstName,
+      lastName,
+      email,
+      hash,
+      passwordConfirm,
+      phoneNum
+    )
 
     // generate node token for new User node
     const token = await graphcool.generateNodeToken(userId, 'User')
@@ -71,9 +86,22 @@ async function getUser(api: GraphQLClient, email: string): Promise<{ User }> {
   return api.request<{ User }>(query, variables)
 }
 
-async function createGraphcoolUser(api: GraphQLClient, firstName: string, lastName:string, email: string, password: string, passwordConfirm: string, phoneNum:string): Promise<string> {
+async function createGraphcoolUser(
+  api: GraphQLClient,
+  firstName: string,
+  lastName: string,
+  email: string,
+  password: string,
+  passwordConfirm: string,
+  phoneNum: string): Promise<string> {
   const mutation = `
-    mutation createGraphcoolUser($firstName: String!, $lastName: String!, $email: String!, $password: String!, $passwordConfirm: String!, $phoneNum: String!) {
+    mutation createGraphcoolUser(
+      $firstName: String!,
+      $lastName: String!,
+      $email: String!,
+      $password: String!,
+      $passwordConfirm: String!,
+      $phoneNum: String!) {
       createUser(
         firstName: $firstName,
         lastName : $lastName,

--- a/server/types.graphql
+++ b/server/types.graphql
@@ -16,7 +16,7 @@
    facebookUserId: String @isUnique
    password: String
    phoneNum: String
-   email: String @isUnique # optional, because it's obtained from Facebook API
+   email: String @isUnique
  }
 
 

--- a/server/types.graphql
+++ b/server/types.graphql
@@ -16,7 +16,7 @@
    facebookUserId: String @isUnique
    password: String
    phoneNum: String
-   email: String # optional, because it's obtained from Facebook API
+   email: String @isUnique # optional, because it's obtained from Facebook API
  }
 
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds a fix for the issues with signup and login.

#### Description of Task to be completed?
Task completed include
- Add title to create family component.
- Update type to make email field unique.
- Add additional fields(firstName, lastName, ...) to signupuserMutation.
- Update signup resolver handler to include added fields and return the firstName of the user.
- Remove manually created mutations.
- Add Asyncstorage to save token on login.

#### How should this be manually tested?
- Clone the repo
- run `yarn install`
- open app on your android simulator
- Click `SIGN UP/LOGIN`.
- On successful signup/login, you would be redirected to the create family page.

#### Any background context you want to provide?
Initially, we called the `createUser` mutation directly from the signupPage, which meant we were not taking advantage of the resolver handler provided by the graphcool template. The question then maybe `why did it work?` We were manually calling on the mutate function and as such the mutation still took place.  This bypass led to two issues:

-  Password not hashed.
- Token not assigned.

 On the other hand, calling the `signupMutation` provided a scaffold for the `createUser` mutation with additional functionalities(like password hashing and token generation). This had also caused the authentication not to work as the password hash did not take place and bycrpt could not compare which the PR addresses.
